### PR TITLE
added ability to select components to be included in junit result 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ In order to build this jar, just run maven without any arguments:
     $ mvn
 
 ## How to use it?
-    java -jar jtl2junit.jar --input <jmeter.jtl> --output <junit.xml> [--testSuiteName <name of the test suite>]
+    java -jar jtl2junit.jar --input <jmeter.jtl> --output <junit.xml> [--testSuiteName <name of the test suite>] [--filter <true/false>]
 
 If the `<name of the test suite>` argument is not given, it will default to `jmeter`.
 
+Sometimes we want selected jmeter samplers' result to convert to junit
+If the `--filter` option is not set to `true`, all the jmeter sample results will be converted to junit result as it is.
+If `--filter true`, only those samples will be converted which have `@junit` as part of their name `ie label`
 
 ## License
 This software is available under GNU GPL license. Please see file `LICENSE` for details.

--- a/src/main/java/com/tguzik/m2u/application/CommandLineParser.java
+++ b/src/main/java/com/tguzik/m2u/application/CommandLineParser.java
@@ -1,6 +1,13 @@
 package com.tguzik.m2u.application;
 
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import com.tguzik.m2u.constants.M2UConstants;
+import com.tguzik.m2u.params.ControlParams;
 
 public class CommandLineParser {
     public static final String APPLICATION_NAME = "jtl2junit";
@@ -14,6 +21,10 @@ public class CommandLineParser {
 
         try {
             final CommandLine cmd = parser.parse( options, argv );
+            
+            String filter = cmd.getOptionValue(M2UConstants.JUNIT_FILTER_SWITCH_NAME);
+            ControlParams.setParams(M2UConstants.JUNIT_FILTER_SWITCH_NAME, filter!=null?filter.toLowerCase():M2UConstants.FALSE);
+            
             return new ProgramOptions( cmd.getOptionValue( CMD_OPTION_INPUT ),
                                        cmd.getOptionValue( CMD_OPTION_OUTPUT ),
                                        cmd.getOptionValue( CMD_OPTION_TESTSUITE_NAME ) );
@@ -50,6 +61,14 @@ public class CommandLineParser {
                                  .longOpt( CMD_OPTION_TESTSUITE_NAME )
                                  .desc( "Name for the generated test suite (default: jmeter)" )
                                  .build() );
+        
+        options.addOption( Option.builder()
+				                .required( false )
+				                .hasArg()
+				                .argName( "JUNIT-FILTER_SWITCH-NAME")
+				                .longOpt( M2UConstants.JUNIT_FILTER_SWITCH_NAME )
+				                .desc( "Name for the junit test switch (default: false)" )
+				                .build() );
 
         return options;
     }

--- a/src/main/java/com/tguzik/m2u/constants/M2UConstants.java
+++ b/src/main/java/com/tguzik/m2u/constants/M2UConstants.java
@@ -1,0 +1,13 @@
+package com.tguzik.m2u.constants;
+
+public class M2UConstants {
+	
+	public static final String JUNIT_FILTER_SWITCH_NAME = "filter";
+
+	public static final String JUNIT_DECORATOR = "@junit";
+	
+	public static final String TRUE = "true";
+	public static final String FALSE = "false";
+	public static final String BLANK = "";
+	
+}

--- a/src/main/java/com/tguzik/m2u/data/JtlToJunitConverter.java
+++ b/src/main/java/com/tguzik/m2u/data/JtlToJunitConverter.java
@@ -3,7 +3,9 @@ package com.tguzik.m2u.data;
 import static com.tguzik.util.CollectionUtils.safe;
 
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
+import com.tguzik.m2u.constants.M2UConstants;
 import com.tguzik.m2u.data.jtl.AssertionResult;
 import com.tguzik.m2u.data.jtl.BaseSample;
 import com.tguzik.m2u.data.jtl.HttpSample;
@@ -12,6 +14,7 @@ import com.tguzik.m2u.data.junit.Failure;
 import com.tguzik.m2u.data.junit.TestCase;
 import com.tguzik.m2u.data.junit.TestSuite;
 import com.tguzik.m2u.data.junit.TestSuites;
+import com.tguzik.m2u.params.ControlParams;
 
 public class JtlToJunitConverter implements BiFunction<String, TestResults, TestSuites> {
 
@@ -22,12 +25,20 @@ public class JtlToJunitConverter implements BiFunction<String, TestResults, Test
 
         suites.setTestGroupName( testSuiteName );
         singleSuite.setName( testSuiteName );
+        
+        String filter = ControlParams.getParam(M2UConstants.JUNIT_FILTER_SWITCH_NAME);
+        Predicate<BaseSample> p = a -> true;
+        if(filter != null && filter.equalsIgnoreCase(M2UConstants.TRUE)){
+        	p = a->a.getLabel().contains(M2UConstants.JUNIT_DECORATOR);
+        }
 
         safe( input.getSamples() ).stream()
+        						  .filter(p)
                                   .map( this::convertSample )
                                   .forEach( singleSuite::addTestCase );
 
         safe( input.getHttpSamples() ).stream()
+        							  .filter(p)
                                       .map( this::convertHttpSample )
                                       .forEach( singleSuite::addTestCase );
 
@@ -41,7 +52,14 @@ public class JtlToJunitConverter implements BiFunction<String, TestResults, Test
 
         tc.setAssertions( safe( input.getAssertionResults() ).size() );
         tc.setClassname( input.getThreadName() );
-        tc.setTestName( input.getThreadName() );
+        
+        String filter = ControlParams.getParam(M2UConstants.JUNIT_FILTER_SWITCH_NAME);
+        if(filter != null && filter.equalsIgnoreCase(M2UConstants.TRUE)){
+        	tc.setTestName( input.getLabel().replace(M2UConstants.JUNIT_DECORATOR, M2UConstants.BLANK) );
+        }else{
+        	tc.setTestName( input.getThreadName() );
+        }
+        
         tc.setTotalTimeSpentInSeconds( input.getElapsedTime() );
         tc.getSystemOut().add( input.toString() );
 

--- a/src/main/java/com/tguzik/m2u/params/ControlParams.java
+++ b/src/main/java/com/tguzik/m2u/params/ControlParams.java
@@ -1,0 +1,17 @@
+package com.tguzik.m2u.params;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControlParams {
+
+	static Map<String, String> paramsMap = new HashMap<>();
+	
+	public static void setParams(String key, String value){
+		paramsMap.put(key, value);
+	}
+	
+	public static String getParam(String key){
+		return paramsMap.get(key);
+	}
+}


### PR DESCRIPTION
JMeter adds all the sampler's result in its result. With this change, this tool will have ability to filter certain components to be included in the junit test result and ignore others. 
Its useful when doing functional tests where you don't want the setup and teardown sampler results in the junit but only the important validations.