### PR TITLE
Enforcing UTF8 encoding for I/O operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In order to build this jar, just run maven without any arguments:
     $ mvn
 
 ## How to use it?
-    java -jar jtl2junit.jar --input <jmeter.jtl> --output <junit.xml> [--testSuiteName <name of the test suite>] [--filter <true/false>]
+    java -jar m2j.jar --input <jmeter.jtl> --output <junit.xml> [--testSuiteName <name of the test suite>] [--filter <true/false>]
 
 If the `<name of the test suite>` argument is not given, it will default to `jmeter`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.7</version>
+            <version>1.4.10</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/tguzik/m2u/application/Main.java
+++ b/src/main/java/com/tguzik/m2u/application/Main.java
@@ -1,6 +1,7 @@
 package com.tguzik.m2u.application;
 
 import java.io.*;
+import java.nio.charset.Charset;
 
 import com.tguzik.m2u.data.JtlToJunitConverter;
 import com.tguzik.m2u.data.jtl.TestResults;
@@ -21,13 +22,16 @@ public class Main {
     }
 
     public void run( ProgramOptions programOptions ) throws IOException {
-        try ( InputStreamReader input = new FileReader( programOptions.getInputFileName() );
-              OutputStreamWriter output = new FileWriter( programOptions.getOutputFileName() ) ) {
+        try ( InputStreamReader input = new InputStreamReader( new FileInputStream( programOptions.getInputFileName() ),
+                                                               Charset.forName("UTF-8").newDecoder() );
+              OutputStreamWriter output = new OutputStreamWriter( new FileOutputStream( programOptions.getOutputFileName() ),
+                                                                  Charset.forName("UTF-8").newEncoder() ) ) {
 
             TestResults jmeterResults = new JmeterXmlConverter().fromXML( input );
             TestSuites junitResults = new JtlToJunitConverter().apply( programOptions.getTestSuiteName(),
                                                                        jmeterResults );
 
+            output.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
             new JunitXmlConverter().toXML( junitResults, output );
         }
     }


### PR DESCRIPTION
This request enforces that the output of the project is UTF8.
Without this modification, it will output a file following the locale of the O.S. which can be wrong if your system does not have a UTF8-based default locale (i.e. Windows Chinese).
With this correction it will generate a valid UTF8 output. Besides, the xml optional header has been added 